### PR TITLE
Fixes a bug where the Dismiss button does not work after screenshot detection

### DIFF
--- a/Source/Backchannel.m
+++ b/Source/Backchannel.m
@@ -91,8 +91,9 @@ static UIViewController *_rootViewController;
     [screenshotDetection start];
 }
 
-- (void)screenshotDetectionCoordinatorCompleted:(BAKScreenshotDetectionCoordinator *)coordinator {
-    [self.coordinators removeObject:coordinator];
+- (void)screenshotDetectionCoordinatorCompleted:(BAKScreenshotDetectionCoordinator *)screenshotDetectionCoordinator {
+    [screenshotDetectionCoordinator.viewController dismissViewControllerAnimated:YES completion:nil];
+    [self.coordinators removeObject:screenshotDetectionCoordinator];
 }
 
 - (NSMutableArray *)coordinators {


### PR DESCRIPTION
Steps to re-create bug:
1. Run the `BackchannelSDK` target on the simulator or a device
2. Tap "Fake a screenshot"
3. Tap "Post"
4. Tap "Dismiss"

Analysis:
When a `BAKFirstRunViewController` is presented by a `BAKScreenshotDetectionCoordinator`, the Dismiss button does not dismiss the presented view controller.

Cause:
The `Backchannel` class does not correctly implement the`BAKScreenshotDetectionDelegate` protocol.

Remedy:
The `Backchannel` class should dismiss `BAKScreenshotDetectionCoordinator`'s view controller in the delegate callback.
