### PR TITLE
Fix reference cycle and memory leak

### DIFF
--- a/Source/Create Message/BAKAuthenticatingCreateMessageCoordinator.m
+++ b/Source/Create Message/BAKAuthenticatingCreateMessageCoordinator.m
@@ -79,7 +79,7 @@
 - (void)startCreation {
     self.createMessageCoordinator.delegate = self;
     [self.createMessageCoordinator start];
-    [self.childCoordinators addObject:self.childCoordinators];
+    [self.childCoordinators addObject:self.createMessageCoordinator];
 }
 
 - (void)coordinatorDidAuthenticate:(BAKAuthenticationCoordinator *)coordinator {


### PR DESCRIPTION
Fix reference cycle and memory leak caused by adding the wrong object to childCoordinatators array.

`BAKAuthenticatingCreateMessageCoordinator`'s `startCreation` method is adding the wrong object to the `childCoordinators` array:

```
- (void)startCreation {
    self.createMessageCoordinator.delegate = self;
    [self.createMessageCoordinator start];
    [self.childCoordinators addObject:self.childCoordinators]; // << should be addObject:self.createMessageCoordinator
}
```
